### PR TITLE
Fix LaTeX error.

### DIFF
--- a/exampleAlgorithm.tex
+++ b/exampleAlgorithm.tex
@@ -33,7 +33,7 @@ In the diagram, the following terms are used:
    \item \textit{cci.}  context change that can be reported imprecisely (see Table~\ref{tab:context-type}).
 \end{itemize}
 
-\begin{figure}[l]
+\begin{figure}
 \begin{center}
   \includegraphics[height=23cm, width=15cm]{algo.png}
   \caption{Delta Mode 1 instruction trace algorithm}


### PR DESCRIPTION
[l] is invalid.  Only h/t/b/p/H (and optional !) are allowed float values.
The figure consumes the whole page so I don't think there's any need to
specify positioning.