### PR TITLE
Introduction improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+
+
+
+To recreate the PDF file, first install the Ubuntu following packages:
+
+```sudo apt-get install texlive-base texlive-latex-base texlive-latex-extra texlive-fonts-extra texlive-science```
+
+Then type `make`.  
+
+You may have to press [ENTER] a couple of times to skip past some error messages.
+

--- a/introduction.tex
+++ b/introduction.tex
@@ -36,7 +36,7 @@ Conceptually, the system has one or more of the following fundamental components
   \item
     A decoder, usually software on an external PC, that takes in the trace
     packets and, with knowledge of the program binary that's running on the
-    originating CPU, reconstructs the program flow. This decoding step can
+    originating hart, reconstructs the program flow. This decoding step can
     be done off-line or in real-time while the CPU is executing.
 \end{itemize}
 

--- a/introduction.tex
+++ b/introduction.tex
@@ -27,7 +27,7 @@ Conceptually, the system has one or more of the following fundamental components
     information to successfully create a processor branch trace and more.
     This is a high bandwidth interface: in most implementations, it will supply
     a large amount of data (instruction address, instruction type, context information, ...)
-    for each CPU execution clock cycle.
+    for each core execution clock cycle.
   \item
     A hardware encoder that takes in the CPU instruction trace and compresses
     it into lower bandwidth trace packets.

--- a/introduction.tex
+++ b/introduction.tex
@@ -42,7 +42,7 @@ Conceptually, the system has one or more of the following fundamental components
 
 In RISC-V, all instructions are executed unconditionally or at least
 their execution can be determined based on the program binary. The
-instructions between the deltas can all assumed to be executed
+instructions between the deltas can all be assumed to be executed
 sequentially. Because of this, there is no need to report sequential 
 instructions in the trace, only whether the branches were taken or not
 and the address of taken indirect branches or jumps. If the program

--- a/introduction.tex
+++ b/introduction.tex
@@ -65,14 +65,10 @@ exception type.  When an interrupt or exception occurs, or the
 processor is halted, the final instruction executed beforehand must be
 included in the trace.
 
-The primary goal of this document is to specify the ingress interface, the
-instruction trace interface between a RISC-V CPU and an encoder. It
-establishes a standard for CPU designers to follow such that they can interface
-with encoders from various IP providers.
-
-In addition, this document also details an example of a compressed branch trace
-algorithm and a packet format to encapsulate the compressed branch trace
-information.  However, this is not a normative part of the specficiation.
+This document serves to specify the ingress port (the signals between
+the RISC-V core and the encoder), compressed branch trace algorithm and
+the packet format used to encapsulate the compressed branch trace
+information.
 
 \subsection{Nomenclature}
 

--- a/introduction.tex
+++ b/introduction.tex
@@ -10,23 +10,42 @@ events, poor implementations or some combination of all of the above.
 It is not always possible to use a debugger to observe behavior of a
 running system as this is intrusive.  Providing visibility of program
 execution is important.  This needs to be done without swamping the
-system with vast amounts of data and one method of achieving this is
-via Processor Branch Trace.
+system with vast amounts of data.
+
+One method of achieving this is via a Processor Branch Trace.
 
 This works by tracking execution from a known start address and sending
-messages about the deltas taken by the program. These deltas are typically
-introduced by jump, call, return and branch type instructions,
+messages about the address deltas taken by the program. These deltas are
+typically introduced by jump, call, return and branch type instructions,
 although interrupts and exceptions are also types of deltas.
 
-Software, known as a decoder, will take this compressed branch trace
-and reconstruct the program flow. This can be done off-line or
-whilst the system is executing.
+Conceptually, the system has one or more of the following fundamental components:
+
+\begin{itemize}
+  \item
+    A CPU with an instruction trace interface that outputs all relevant
+    information to successfully create a processor branch trace and more.
+    This is a high bandwidth interface: in most implementations, it will supply
+    a large amount of data (instruction address, instruction type, context information, ...)
+    for each CPU execution clock cycle.
+  \item
+    A hardware encoder that takes in the CPU instruction trace and compresses
+    it into lower bandwidth trace packets.
+  \item
+    A transmission channel that to transmit or a memory to store
+    these trace packets.
+  \item
+    A decoder, usually software on an external PC, that takes in the trace
+    packets and, with knowledge of the program binary that's running the
+    originating CPU, reconstructs the program flow. This decoding step can
+    be done off-line or in real-time while the CPU is executing.
+\end{itemize}
 
 In RISC-V, all instructions are executed unconditionally or at least
-their execution can be determined based on the program, the
-instructions between the deltas are assumed to be executed
-sequentially.  This characteristic means that there is no need to
-report them via the trace, only whether the branches were taken or not
+their execution can be determined based on the execution binary. The
+instructions between the deltas can all assumed to be executed
+sequentially. Because of this, there is no need to report sequential 
+instructions in the trace, only whether the branches were taken or not
 and the address of taken indirect branches or jumps. If the program
 counter is changed by an amount that cannot be determined from the
 execution binary, the trace decoder needs to be given the destination
@@ -45,12 +64,16 @@ where normal program flow ceased, as well as give an indication of the
 asynchronous destination which may be as simple as reporting the
 exception type.  When an interrupt or exception occurs, or the
 processor is halted, the final instruction executed beforehand must be
-traced.
+included in the trace.
 
-This document serves to specify the ingress port (the signals between
-the RISC-V core and the encoder), compressed branch trace algorithm and
-the packet format used to encapsulate the compressed branch trace
-information.
+The primary goal of this document is to specify the ingress interface, the
+instruction trace interface between a RISC-V CPU and an encoder. It
+establishes a standard for CPU designers to follow such that they can interface
+with encoders from various IP providers.
+
+In addition, this document also details an example of a compressed branch trace
+algorithm and a packet format to encapsulate the compressed branch trace
+information.  However, this is not a normative part of the specficiation.
 
 \subsection{Nomenclature}
 

--- a/introduction.tex
+++ b/introduction.tex
@@ -23,7 +23,7 @@ Conceptually, the system has one or more of the following fundamental components
 
 \begin{itemize}
   \item
-    A CPU with an instruction trace interface that outputs all relevant
+    A core with an instruction trace interface that outputs all relevant
     information to successfully create a processor branch trace and more.
     This is a high bandwidth interface: in most implementations, it will supply
     a large amount of data (instruction address, instruction type, context information, ...)

--- a/introduction.tex
+++ b/introduction.tex
@@ -35,7 +35,7 @@ Conceptually, the system has one or more of the following fundamental components
     A transmission channel to transmit or a memory to store these trace packets.
   \item
     A decoder, usually software on an external PC, that takes in the trace
-    packets and, with knowledge of the program binary that's running the
+    packets and, with knowledge of the program binary that's running on the
     originating CPU, reconstructs the program flow. This decoding step can
     be done off-line or in real-time while the CPU is executing.
 \end{itemize}

--- a/introduction.tex
+++ b/introduction.tex
@@ -83,9 +83,11 @@ attributes within a packet.
 Items in \textit {italics} refer to parameters either built into the
 hardware or configurable hardware values.
 
-A decoder is a piece of software that takes the packets emitted by the
-encoder and is able to reconstruct the execution flow of the code
-executed in the RISC-V core.
+An encoder is a piece of hardware that takes in RISC-V instruction data
+on its ingress port and transforms it into trace packets.
+
+A decoder is a piece of software that takes the trace packets emitted by the
+encoder and reconstructs the execution flow of the code executed in the RISC-V core.
 
 RISC-V has the following definitions:
 \begin{itemize}
@@ -102,4 +104,4 @@ If an exception or interrupt doesn't trap, the program counter does not
 change. So, there is no need to trace all exceptions/interrupts, just
 traps.
 
-In this document interrupts and exceptions traced are only those that cause traps to be taken.
+In this document, interrupts and exceptions are only traced when they cause traps to be taken.

--- a/introduction.tex
+++ b/introduction.tex
@@ -32,8 +32,7 @@ Conceptually, the system has one or more of the following fundamental components
     A hardware encoder that takes in the CPU instruction trace and compresses
     it into lower bandwidth trace packets.
   \item
-    A transmission channel that to transmit or a memory to store
-    these trace packets.
+    A transmission channel to transmit or a memory to store these trace packets.
   \item
     A decoder, usually software on an external PC, that takes in the trace
     packets and, with knowledge of the program binary that's running the
@@ -42,7 +41,7 @@ Conceptually, the system has one or more of the following fundamental components
 \end{itemize}
 
 In RISC-V, all instructions are executed unconditionally or at least
-their execution can be determined based on the execution binary. The
+their execution can be determined based on the program binary. The
 instructions between the deltas can all assumed to be executed
 sequentially. Because of this, there is no need to report sequential 
 instructions in the trace, only whether the branches were taken or not

--- a/introduction.tex
+++ b/introduction.tex
@@ -37,7 +37,7 @@ Conceptually, the system has one or more of the following fundamental components
     A decoder, usually software on an external PC, that takes in the trace
     packets and, with knowledge of the program binary that's running on the
     originating hart, reconstructs the program flow. This decoding step can
-    be done off-line or in real-time while the CPU is executing.
+    be done off-line or in real-time while the hart is executing.
 \end{itemize}
 
 In RISC-V, all instructions are executed unconditionally or at least


### PR DESCRIPTION
This patch addresses the following issues:

- It adds instructions on how to create a new PDF file on an Ubuntu system.
- The first time 'delta' is used, it uses 'address delta' instead to make clearer what is meant by a delta.
- it adds an overall systems view that was currently lacking, and define the major components in the system. (Eventually, a diagram will need to be added.)
- it clarifies which part of the spec is normative (the interface between CPU and encoder) and which part is not (all the rest, which is dependent on what an IP provider decides to implement).
- it defines 'encoder'. In the previous version, 'decoder' was used without mentioning the word 'encoder'.