### PR TITLE
Branch trace chapter changes

### DIFF
--- a/branchTrace.tex
+++ b/branchTrace.tex
@@ -174,9 +174,9 @@ from just the exception cause.
 
 Related parameters: \textit{call\_counter\_size\_p}, \textit{return\_stack\_size\_p}.
 
-Although a function return is usually an indirect jump, well behaved programs following a 
-calling convention return to the point in the program from which the function was called, 
-and as such it is possible to determine the execution path without being explicitly notified 
+Although a function return is usually an indirect jump, well behaved programs return to the
+point in the program from which the function was called using a standard calling convention.
+For those programs, it is possible to determine the execution path without being explicitly notified
 of the destination address of the return.  The implicit return mode can result in very
 significant improvements in trace encoder efficiency.
 
@@ -192,7 +192,7 @@ Such a scheme is low cost, and will work as long as programs are "well behaved".
 return address is actually that of the instruction following the associated call.  As such, any program that
 modifies return addresses cannot be traced using this mode with this minimal implementation.
 
-Alternatively, the encoder can maintain a stack of expected return addresses, and only treat the 
+Alternatively, the encoder can maintain a stack of expected return addresses, and only treat a
 return as inferable if the actual return address matches the prediction.  This is fully robust for all
 programs, but is more expensive to implement.  In this case, if a return address does not match the prediction, 
 it must be reported explicitly via a packet, along with the number of return addresses

--- a/branchTrace.tex
+++ b/branchTrace.tex
@@ -132,8 +132,18 @@ Here are common examples of such modes:
     are not encoded as taken/non-taken, but as a more efficient branch count number.
 \end{itemize}
 
-Each optional mode lists the associated parameters; see Table~\ref{tab:parameters} for further 
-details.
+Modes may have associated parameters; see Table~\ref{tab:parameters} for further details.
+
+\subsection{Delta address mode} \label{sec:delta-address}
+
+Related parameters: None
+
+In delta address mode, non-sequential program counter changes
+are encoded as the difference between the previous and the current
+address. This kind of encoding require less bits than encoding the
+full address, and thus results in higher compression ratios.
+
+This is the default encoding mode.
 
 \subsection{Full address mode} \label{sec:full-address}
 

--- a/branchTrace.tex
+++ b/branchTrace.tex
@@ -68,12 +68,14 @@ RISC-V ISA.
 
 \subsection{Interrupts and Exceptions} \label{interruptsexceptions}
 
-Interrupts are a different type of delta, they generally occur
+Interrupts are a different type of delta that generally occur
 asynchronously to the program's execution rather than intentionally as
 a result of a specific instruction or event. Exceptions can be thought
 of in the same way, even though they can be typically linked back to a
-specific instruction address.  The decoder generally does not know
-where an interrupt occurs in the instruction sequence, so the trace
+specific instruction address.
+
+The decoder generally does not know
+where an interrupt occured in the instruction sequence, so the trace
 must report the address where normal program flow ceased, as well as
 give an indication of the asynchronous destination which may be as
 simple as reporting the exception type.  When an interrupt or

--- a/branchTrace.tex
+++ b/branchTrace.tex
@@ -216,7 +216,10 @@ can still result in a relatively large volume of trace packets.  For example:
   \item Breakpoints, which in some implementations also spin in an idle loop.
 \end{itemize}
 
-The prediction scheme implemented in the encoder will need to be modelled in the decoder software.  
+A significant coding efficiency can be obtained by the addition of a branch predictor in the encoder. To keep
+the encoder and decoder synchronized, a predictor with identical behavior will need to be modelled in the decoder
+software.
+
 The predictor shall comprise a lookup table of 2\textsuperscript{N} entries, where N is specified by a parameter.  
 Each entry is indexed by bits N:1 of the instruction address (or N+1:2 if compressed instructions aren't supported), 
 and each contains a 2-bit prediction state:
@@ -227,8 +230,8 @@ and each contains a 2-bit prediction state:
   \item 10: predict 1, transition to 11 if prediction succeeds, else 00.
 \end{itemize}
 
-We could also consider the gShare predictor (see Hennessy \& Patterson).  Some further experimentation is needed
-to determine the benefits of different lookup table sizes and predictor algorithms.
+Other predictors, such as the gShare predictor (see Hennessy \& Patterson), should be considered.  Some further
+experimentation is needed to determine the benefits of different lookup table sizes and predictor algorithms.
 
-The lookup table entries are initialized to 00 when a format 3 \textit{te\_inst} packet is sent.
+The lookup table entries are initialized to 00 when a format 3 \textit{te\_inst} synchronization packet is sent.
 

--- a/branchTrace.tex
+++ b/branchTrace.tex
@@ -1,8 +1,6 @@
 \chapter{Branch Trace} \label{Branch Trace}
 
 
-\section{Instruction Delta Tracing} \label{Delta Tracing}
-
 Instruction delta tracing, also known as branch tracing, works by
 tracking execution from a known start address by sending information
 about the deltas taken by the program. Deltas are typically introduced

--- a/branchTrace.tex
+++ b/branchTrace.tex
@@ -177,18 +177,18 @@ Related parameters: \textit{call\_counter\_size\_p}, \textit{return\_stack\_size
 Although a function return is usually an indirect jump, well behaved programs following a 
 calling convention return to the point in the program from which the function was called, 
 and as such it is possible to determine the execution path without being explicitly notified 
-of the destination address of the return.  The 'implicit return' option can result in very 
-significant improvements in trace encoder efficiency.  
+of the destination address of the return.  The implicit return mode can result in very
+significant improvements in trace encoder efficiency.
 
-Returns can only be treated as inferable if the associated call has already been reported in 
-a \textit{te\_inst} packet.  The encoder must ensure that this is the case.  This can be accomplished 
-by utilizing a counter to keep track of the number of nested calls being traced.  The counter 
-increments on calls (but not tail calls), and decrements on returns (see Section~\ref{Jump Classes} 
+Returns can only be treated as inferable if the associated call has already been reported in
+an earlier \textit{te\_inst} packet.  The encoder must ensure that this is the case.  This can be accomplished
+by utilizing a counter to keep track of the number of nested calls being traced.  The counter
+increments on calls (but not tail calls), and decrements on returns (see Section~\ref{Jump Classes}
 for definitions).  The counter will not over or underflow, and is reset to 0 whenever a format 3 
-\textit{te\_inst} packet is sent.  Returns will be treated as inferable and will not generate a trace 
-packet if the count is non-zero (i.e. the associated call was already reported in a \textit{te\_inst} packet).
+\textit{te\_inst} synchronization packet is sent.  Returns will be treated as inferable and will not generate a trace
+packet if the count is non-zero (i.e. the associated call was already reported in an earlier \textit{te\_inst} packet).
 
-Such a scheme is low cost, and will work as long as programs are "well behaved".  It does not check that the 
+Such a scheme is low cost, and will work as long as programs are "well behaved".  The encoder does not check that the
 return address is actually that of the instruction following the associated call.  As such, any program that
 modifies return addresses cannot be traced using this mode with this minimal implementation.
 

--- a/branchTrace.tex
+++ b/branchTrace.tex
@@ -204,7 +204,7 @@ currently on the stack.  This ensures that the decoder can determine which retur
 
 Related parameters: \textit{bpred\_size\_p}.
 
-In a straightforward encoder, the outcome of each executed branch is stored in
+Without branch prediction, the outcome of each executed branch is stored in
 a branch map: a bit vector in which the taken/non-taken status of each branch is stored in
 chronological order.
 

--- a/branchTrace.tex
+++ b/branchTrace.tex
@@ -181,12 +181,12 @@ of the destination address of the return.  The implicit return mode can result i
 significant improvements in trace encoder efficiency.
 
 Returns can only be treated as inferable if the associated call has already been reported in
-an earlier \textit{te\_inst} packet.  The encoder must ensure that this is the case.  This can be accomplished
+an earlier packet.  The encoder must ensure that this is the case.  This can be accomplished
 by utilizing a counter to keep track of the number of nested calls being traced.  The counter
 increments on calls (but not tail calls), and decrements on returns (see Section~\ref{Jump Classes}
-for definitions).  The counter will not over or underflow, and is reset to 0 whenever a format 3 
-\textit{te\_inst} synchronization packet is sent.  Returns will be treated as inferable and will not generate a trace
-packet if the count is non-zero (i.e. the associated call was already reported in an earlier \textit{te\_inst} packet).
+for definitions).  The counter will not over or underflow, and is reset to 0 whenever a
+synchronization packet is sent.  Returns will be treated as inferable and will not generate a trace
+packet if the count is non-zero (i.e. the associated call was already reported in an earlier packet).
 
 Such a scheme is low cost, and will work as long as programs are "well behaved".  The encoder does not check that the
 return address is actually that of the instruction following the associated call.  As such, any program that
@@ -195,7 +195,7 @@ modifies return addresses cannot be traced using this mode with this minimal imp
 Alternatively, the encoder can maintain a stack of expected return addresses, and only treat the 
 return as inferable if the actual return address matches the prediction.  This is fully robust for all
 programs, but is more expensive to implement.  In this case, if a return address does not match the prediction, 
-it must be reported explicitly via a \textit{te\_inst} packet, along with the number of return addresses 
+it must be reported explicitly via a packet, along with the number of return addresses
 currently on the stack.  This ensures that the decoder can determine which return is being reported. 
 
 \subsection{Branch prediction mode} \label{sec:branch-prediction}

--- a/branchTrace.tex
+++ b/branchTrace.tex
@@ -9,9 +9,7 @@ about the deltas taken by the program. Deltas are typically introduced
 by jump, call, return and branch type instructions, although
 interrupts and exceptions are also types of deltas.
 
-Instruction trace delta modes provide an efficient encoding of an
-instruction sequence by exploiting the deterministic way the processor
-behaves based on the program it is executing. The approach relies on
+The approach relies on
 an offline copy of the program binary being available to the decoder, so it
 is generally unsuitable for either dynamic (self-modifying) programs
 or those where access to the program binary is prohibited.
@@ -33,6 +31,10 @@ are straightforward as they generally operate in a known address
 space, often mapping directly to physical memory. Dynamically linked
 programs require the debugger to keep track of memory allocation
 operations using either trace or stop-mode debugging.
+
+Various instruction trace delta modes can improve the efficiency in which
+the instruction sequence is encoded by exploiting the deterministic way the processor
+behaves based on the program it is executing.
 
 \section{Contents of an Instruction Delta Trace} \label{Trace Contents}
 

--- a/branchTrace.tex
+++ b/branchTrace.tex
@@ -233,5 +233,5 @@ and each contains a 2-bit prediction state:
 Other predictors, such as the gShare predictor (see Hennessy \& Patterson), should be considered.  Some further
 experimentation is needed to determine the benefits of different lookup table sizes and predictor algorithms.
 
-The lookup table entries are initialized to 00 when a format 3 \textit{te\_inst} synchronization packet is sent.
+The lookup table entries are initialized to 00 when a synchronization packet is sent.
 

--- a/branchTrace.tex
+++ b/branchTrace.tex
@@ -202,8 +202,12 @@ currently on the stack.  This ensures that the decoder can determine which retur
 
 Related parameters: \textit{bpred\_size\_p}.
 
-Whilst recording the taken/not-taken status of each branch in a branch map is efficient, there are 
-some cases where this can result in a relatively large volume of trace.  For example:
+In a straightforward encoder, the outcome of each executed branch is stored in
+a branch map: a bit vector in which the taken/non-taken status of each branch is stored in
+chronological order.
+
+While this encoding is efficient, at 1 bit per branch, there are some cases where this
+can still result in a relatively large volume of trace packets.  For example:
 
 \begin{itemize}
   \item Executing tight loops of straight-line code.  Each iteration of the loop will add a bit to the branch map;

--- a/branchTrace.tex
+++ b/branchTrace.tex
@@ -162,8 +162,7 @@ addresses in the \textbf{\textit{utvec/stvec/mvec}} CSR registers.
 In some RISC-V implementations, the lower address bits are stored in
 the \textbf{\textit{ucause/scause/mcause}} CSR registers.
 
-By default, both the vec and cause values are reported when an exception or interrupt occurs,
-via the the format 3, subformat 1 packet.
+By default, both the vec and cause values are reported when an exception or interrupt occurs.
 
 The implicit exception mode omits vec, the trap handler address, from the trace and
 thus improves efficiency.

--- a/branchTrace.tex
+++ b/branchTrace.tex
@@ -36,12 +36,13 @@ operations using either trace or stop-mode debugging.
 
 \subsection{Sequential Instructions} \label{Sequential Instructions}
 
-For instruction set architectures where all instructions are executed
+For instruction set architectures such as RISC-V where all instructions are executed
 unconditionally or at least their execution can be determined based on
-the program, the instructions between the deltas are assumed to be
-executed sequentially. This characteristic means that there is no need
-to report them via the trace, only whether the branches were taken or not
-and the addresses of taken indirect jumps.
+the program binary, the instructions between the deltas are assumed to be
+executed sequentially. Consequently, there is no need
+to report them in the trace. The trace only needs to contain whether
+branches were taken or not, the addresses of taken indirect jumps, or
+other program counter discontinuities.
 
 \subsection{Uninferable PC Discontinuities} \label{uninfpc}
 

--- a/branchTrace.tex
+++ b/branchTrace.tex
@@ -149,9 +149,9 @@ This is the default encoding mode.
 
 Related parameters: None
 
-All packet formats apart from format 3 output addresses in differential form by default.
-An option to output full addresses for all packet formats is a useful debugging aid for 
-software decoder developers.  It will always result in less efficient trace encoding.
+In full address mode, all addresses in the trace are encoded as absolute addresses instead
+of in differential form. This kind of encoding is always less efficient, but it can be a useful 
+debugging aid for software decoder developers.
 
 \subsection{Implicit exception mode} \label{sec:implicit-exception}
 

--- a/branchTrace.tex
+++ b/branchTrace.tex
@@ -12,12 +12,14 @@ interrupts and exceptions are also types of deltas.
 Instruction trace delta modes provide an efficient encoding of an
 instruction sequence by exploiting the deterministic way the processor
 behaves based on the program it is executing. The approach relies on
-an offline copy of the program being available to the decoder, so it
+an offline copy of the program binary being available to the decoder, so it
 is generally unsuitable for either dynamic (self-modifying) programs
-or those where access to the program binary is prohibited. There is no
-need for either assembly or high-level source code to be available,
-although such source code will aid the debugger in presenting the
-decoded trace.
+or those where access to the program binary is prohibited.
+
+While the program binary is sufficient, access to the assembly or
+higher-level source code will improve the ability of the decoder to present
+the decoded trace in the debugger by annotating the traced instructions with
+source code line numbers and labels, variable names etc.
 
 This approach can be extended to cope with small sections of
 deterministically dynamic code by arranging for the decoder to request

--- a/branchTrace.tex
+++ b/branchTrace.tex
@@ -32,7 +32,7 @@ space, often mapping directly to physical memory. Dynamically linked
 programs require the debugger to keep track of memory allocation
 operations using either trace or stop-mode debugging.
 
-\section{Contents of an Instruction Delta Trace} \label{Trace Contents}
+\section{Instruction Delta Trace Concepts} \label{Trace Concepts}
 
 \subsection{Sequential Instructions} \label{Sequential Instructions}
 

--- a/branchTrace.tex
+++ b/branchTrace.tex
@@ -32,10 +32,6 @@ space, often mapping directly to physical memory. Dynamically linked
 programs require the debugger to keep track of memory allocation
 operations using either trace or stop-mode debugging.
 
-Various instruction trace delta modes can improve the efficiency in which
-the instruction sequence is encoded by exploiting the deterministic way the processor
-behaves based on the program it is executing.
-
 \section{Contents of an Instruction Delta Trace} \label{Trace Contents}
 
 \subsection{Sequential Instructions} \label{Sequential Instructions}

--- a/branchTrace.tex
+++ b/branchTrace.tex
@@ -120,8 +120,8 @@ Here are common examples of such modes:
   \item full address mode:
     program counter discontinuities are encoded as absolute address values.
   \item implicit exception mode:
-    destination addresses of CPU exceptions are assumed to be known by the decoder, and thus not encoded
-    in the trace.
+    the destination address of an exception (i.e. the address of the exception trap) is assumed to 
+    be known by the decoder, and thus not encoded in the trace.
   \item implicit return mode:
     the destination address of function call returns is derived from a call stack, and thus not encoded
     in the trace.

--- a/branchTrace.tex
+++ b/branchTrace.tex
@@ -57,10 +57,14 @@ register rather than a constant embedded in the program binary.
 
 \subsection{Branches} \label{branches}
 
-When a branch occurs, the decoder must be informed of whether it was
-taken or not.  For a direct branch, this is sufficient.  There are no
-indirect branches in RISC-V; an indirect jump is an uninferable PC
-discontinuity.
+A branch is an instruction where a jump is conditional on the
+value of a register or a flag. For a decoder to able to follow program flow,
+the trace must include whether a branch was taken or not.
+
+For a direct branch, where the destination address is a constant that
+is encoded in the program binary, no further information is required.
+Direct branches are the only type of branch that is supported by the
+RISC-V ISA.
 
 \subsection{Interrupts and Exceptions} \label{interruptsexceptions}
 

--- a/branchTrace.tex
+++ b/branchTrace.tex
@@ -46,12 +46,14 @@ other program counter discontinuities.
 
 \subsection{Uninferable PC Discontinuities} \label{uninfpc}
 
-If the program counter is changed by an amount that cannot be
-inferred from the execution binary, the trace decoder needs to be
-given the destination address (i.e. the address of the next valid
-instruction).  Examples of this are indirect jumps, where
+An uninferable program counter discontinuity is a program counter change
+that can not be inferred from the program binary alone. For these cases,
+the instruction delta trace must include a destination address: the
+address of the next valid instruction.
+
+Examples of this are indirect jumps, where
 the next instruction address is determined by the contents of a
-register rather than a constant embedded in the source code.
+register rather than a constant embedded in the program binary.
 
 \subsection{Branches} \label{branches}
 

--- a/branchTrace.tex
+++ b/branchTrace.tex
@@ -108,6 +108,31 @@ exception handler (hardware context change).
 
 \section{Optional and run-time configurable modes} \label{optional}
 
+An instruction trace encoder may support multiple tracing modes.
+To ensure that the decoder treats the incoming packets
+correctly, it needs to be informed of the current active configuration.
+The configuration is reported by a packet that is issued by the encoder
+whenever the encoder configuration is changed.
+
+Here are common examples of such modes:
+
+\begin{itemize}
+  \item delta address mode:
+    program counter discontinuities are encoded as differences instead of absolute address values.
+  \item full address mode:
+    program counter discontinuities are encoded as absolute address values.
+  \item implicit exception mode:
+    destination addresses of CPU exceptions are assumed to be known by the decoder, and thus not encoded
+    in the trace.
+  \item implicit return mode:
+    the destination address of function call returns is derived from a call stack, and thus not encoded
+    in the trace.
+  \item branch prediction mode:
+    branches that are predicted correctly by an encoder branch predictor (and an identical copy in the decoder)
+    are not encoded as taken/non-taken, but as a more efficient branch count number.
+\end{itemize}
+
+
 The following modes are optional, and if present must be run-time selectable.  The 
 active run-time options must be reported in the \textit{te\_support} packet, which is issued by the
 encoder whenever the encoder configuration is changed.

--- a/branchTrace.tex
+++ b/branchTrace.tex
@@ -32,6 +32,8 @@ space, often mapping directly to physical memory. Dynamically linked
 programs require the debugger to keep track of memory allocation
 operations using either trace or stop-mode debugging.
 
+\section{Contents of an Instruction Delta Trace} \label{Trace Contents}
+
 \subsection{Sequential Instructions} \label{Sequential Instructions}
 
 For instruction set architectures where all instructions are executed
@@ -41,7 +43,7 @@ executed sequentially. This characteristic means that there is no need
 to report them via the trace, only whether the branches were taken or not
 and the addresses of taken indirect jumps.
 
-\subsection{Uninferable PC Discontinuity} \label{uninfpc}
+\subsection{Uninferable PC Discontinuities} \label{uninfpc}
 
 If the program counter is changed by an amount that cannot be
 inferred from the execution binary, the trace decoder needs to be
@@ -95,7 +97,7 @@ exception handler (hardware context change).
 \item After a prolonged period of time.
 \end{itemize}
 
-\subsection{Optional and run-time configurable modes} \label{optional}
+\section{Optional and run-time configurable modes} \label{optional}
 
 The following modes are optional, and if present must be run-time selectable.  The 
 active run-time options must be reported in the \textit{te\_support} packet, which is issued by the
@@ -104,7 +106,7 @@ encoder whenever the encoder configuration is changed.
 Each optional mode lists the associated parameters; see Table~\ref{tab:parameters} for further 
 details.
 
-\subsubsection{Full address} \label{sec:full-address}
+\subsection{Full address mode} \label{sec:full-address}
 
 Related parameters: None
 
@@ -112,7 +114,7 @@ All packet formats apart from format 3 output addresses in differential form by 
 An option to output full addresses for all packet formats is a useful debugging aid for 
 software decoder developers.  It will always result in less efficient trace encoding.
 
-\subsubsection{Implicit exception} \label{sec:implicit-exception}
+\subsection{Implicit exception mode} \label{sec:implicit-exception}
 
 Related parameters: None
 
@@ -124,7 +126,7 @@ via the the format 3, subformat 1 packet.  The 'implicit exception' option omits
 trap handler address, and will improve efficiency in cases where the decoder can infer 
 the address of the trap handler from just the exception cause.
 
-\subsubsection{Implicit return} \label{sec:implicit-return}
+\subsection{Implicit return mode} \label{sec:implicit-return}
 
 Related parameters: \textit{call\_counter\_size\_p}, \textit{return\_stack\_size\_p}.
 
@@ -152,7 +154,7 @@ programs, but is more expensive to implement.  In this case, if a return address
 it must be reported explicitly via a \textit{te\_inst} packet, along with the number of return addresses 
 currently on the stack.  This ensures that the decoder can determine which return is being reported. 
 
-\subsubsection{Branch prediction} \label{sec:branch-prediction}
+\subsection{Branch prediction mode} \label{sec:branch-prediction}
 
 Related parameters: \textit{bpred\_size\_p}.
 

--- a/branchTrace.tex
+++ b/branchTrace.tex
@@ -7,6 +7,10 @@ about the deltas taken by the program. Deltas are typically introduced
 by jump, call, return and branch type instructions, although
 interrupts and exceptions are also types of deltas.
 
+Instruction delta tracing provides an efficient encoding of an
+instruction sequence by exploiting the deterministic way the processor
+behaves based on the program it is executing.
+
 The approach relies on
 an offline copy of the program binary being available to the decoder, so it
 is generally unsuitable for either dynamic (self-modifying) programs

--- a/branchTrace.tex
+++ b/branchTrace.tex
@@ -157,13 +157,19 @@ debugging aid for software decoder developers.
 
 Related parameters: None
 
-The exception handler base address is specified by \textbf{\textit{utvec/stvec/mtvec}}, and 
-in some RISC-V implementations the lower address bits can be specified by 
-\textbf{\textit{ucause/scause/mcause}}.  
-By default, both these values are reported when an exception or interrupt occurs, 
-via the the format 3, subformat 1 packet.  The 'implicit exception' option omits the 
-trap handler address, and will improve efficiency in cases where the decoder can infer 
-the address of the trap handler from just the exception cause.
+The RISC-V Privileged ISA specification stores exception handler base
+addresses in the \textbf{\textit{utvec/stvec/mvec}} CSR registers.
+In some RISC-V implementations, the lower address bits are stored in
+the \textbf{\textit{ucause/scause/mcause}} CSR registers.
+
+By default, both the vec and cause values are reported when an exception or interrupt occurs,
+via the the format 3, subformat 1 packet.
+
+The implicit exception mode omits vec, the trap handler address, from the trace and
+thus improves efficiency.
+
+This mode can only be used if the decoder can infer the address of the trap handler
+from just the exception cause.
 
 \subsection{Implicit return mode} \label{sec:implicit-return}
 

--- a/branchTrace.tex
+++ b/branchTrace.tex
@@ -132,11 +132,6 @@ Here are common examples of such modes:
     are not encoded as taken/non-taken, but as a more efficient branch count number.
 \end{itemize}
 
-
-The following modes are optional, and if present must be run-time selectable.  The 
-active run-time options must be reported in the \textit{te\_support} packet, which is issued by the
-encoder whenever the encoder configuration is changed.
-
 Each optional mode lists the associated parameters; see Table~\ref{tab:parameters} for further 
 details.
 


### PR DESCRIPTION
- split up in multiple sections. It made no sense to group delta trace contents and delta trade modes in the same section
- reword to be more specific or explicit
- add definitions where one was mission (e.g. what is branch, what is a branch map)
- give short overview of modes before diving into the details

Potentially controversial: 

remove all references to packet format this and subformat that. These formats were never properly introduced before, resulting in a WTF moment when reading the spec the first time. Going into that kind of detail at this point of the spec is a distraction.

It makes IMO much more sense to talk about 'a synchronization packet' than to talk about 'a format 3 te_inst packet', *even if these packets were properly defined earlier.*

I have removed the references to these detailed packet formats from the text in separate commits, so they can easily cherry picked away if the consensus goes toward keeping them. If that is the case, there should at least be additional section first that introduces the different type of packet.