### PR TITLE
typo fix: itype -> dtype table reference

### DIFF
--- a/ingressPort.tex
+++ b/ingressPort.tex
@@ -608,7 +608,7 @@ one of the following groups:
         \hline
         \textbf{dretire} & M & Data access retired (when high)\\
         \hline
-        \textbf{dtype}[\textit{dtype\_width\_p}-1:0] & M & Data access type.  Encoding given in Table~\ref{tab:itype}\\
+        \textbf{dtype}[\textit{dtype\_width\_p}-1:0] & M & Data access type.  Encoding given in Table~\ref{tab:dtype}\\
         \hline
         \textbf{daddr}[\textit{daddress\_width\_p}-1:0] & M & The data access address\\
         \hline


### PR DESCRIPTION
Fixed minor typo in table reference